### PR TITLE
Use custbody_invoice_status instd of statusref

### DIFF
--- a/mp_cl_zee_comm_inv_datatable.js
+++ b/mp_cl_zee_comm_inv_datatable.js
@@ -183,7 +183,7 @@ function loadDatatable() {
                     }
                 }
 
-                var invoice_status = billResult.getText('statusref');
+                var invoice_status = billResult.getValue('custbody_invoice_status');
 
                 invoice_date = dateNetsuite2DateSelectedFormat(invoice_date);
                 total_revenue = financial(total_revenue);

--- a/mp_ss_zee_commission_page.js
+++ b/mp_ss_zee_commission_page.js
@@ -89,7 +89,7 @@ function calculateCommissions() {
                 var invoice_id = billResult.getValue('custbody_invoice_reference');
                 var bill_number = billResult.getValue('invoicenum');
                 var invoice_type = billResult.getValue('custbody_related_inv_type');
-                var invoice_status = billResult.getValue('statusref');
+                var invoice_status = billResult.getValue('custbody_invoice_status');
 
                 // Revenues
                 var total_amount = parseFloat(billResult.getValue('custbody_invoicetotal'));
@@ -102,7 +102,7 @@ function calculateCommissions() {
                 if (isNullorEmpty(invoice_type)) { // Services
 
                     switch (invoice_status) {
-                        case 'open':        // unpaid
+                        case 'Open':        // unpaid
                             unpaid_services_revenues_tax += revenue_tax;
                             unpaid_services_commissions_tax += tax_commission;
                             unpaid_services_revenues_total += total_amount;
@@ -110,7 +110,7 @@ function calculateCommissions() {
                             nb_unpaid_services += 1;
                             break;
 
-                        case 'paidInFull':  // paid
+                        case 'Paid In Full':  // paid
                             paid_services_revenues_tax += revenue_tax;
                             paid_services_commissions_tax += tax_commission;
                             paid_services_revenues_total += total_amount;
@@ -144,7 +144,7 @@ function calculateCommissions() {
                     })
 
                     switch (invoice_status) {
-                        case 'open':        // unpaid
+                        case 'Open':        // unpaid
                             unpaid_products_revenues_tax += revenue_tax;
                             unpaid_products_commissions_tax += tax_commission;
                             unpaid_products_revenues_total += total_amount;
@@ -156,7 +156,7 @@ function calculateCommissions() {
                             nb_unpaid_products += 1;
                             break;
 
-                        case 'paidInFull':  // paid
+                        case 'Paid In Full':  // paid
                             paid_products_revenues_tax += revenue_tax;
                             paid_products_commissions_tax += tax_commission;
                             paid_products_revenues_total += total_amount;


### PR DESCRIPTION
The field 'status_ref' of the bill was used for the var `invoice_status` instead of 'custbody_invoice_status'. The search 'customsearch_zee_commission_page' has been modified to include the new result.